### PR TITLE
Allow certain requests paths to skip the header check

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,17 +47,22 @@ In the web.xml of your Java web application:
 
 This filter should be added at the top of the web.xml so that it is invoked before other filters.
 
-You may also whitelist the endpoints to exclude from the CORS filter by adding the param-name **path-exclusion-pattern**
+The servlet filter may be configured to exclude specific paths by specifying the **path-exclusion-prefix** init parameter. Requests to excluded paths are passed through the filter without inspecting headers.
+
 The values are a list of comma or whitespace separated values for prefixing endpoints to exclude.
-e.g. /api/ will exclude /api/some/endpoint/here from the cors filter. It is recommended to have the both beginning and trailing / in your path exclusion pattern.
+e.g. `/api/` will exclude `/api/some/endpoint/here` from the cors filter. It is recommended to have the both beginning and trailing / in your path exclusion pattern.
 
 ````
 	<filter>
 		<filter-name>CORSFilter</filter-name>
 		<filter-class>com.tasktop.servlet.cors.CorsHeaderScrutinyServletFilter</filter-class>
 		<init-param>
-		  <param-name>path-exclusion-pattern</param-name>
-		  <param-value>/api/</param-value>
+			<param-name>path-exclusion-prefix</param-name>
+			<param-value>
+				/api/one/
+				/api/two/
+				/other/api/
+			</param-value>
 		</init-param>
 	</filter>
 	<filter-mapping>
@@ -66,6 +71,7 @@ e.g. /api/ will exclude /api/some/endpoint/here from the cors filter. It is reco
 	</filter-mapping>
 ````
 
+In the example above, paths with the prefix as `/api/one/`, `api/two` and `other/api` would skip the header check.
 
 Building
 ========

--- a/README.md
+++ b/README.md
@@ -47,10 +47,14 @@ In the web.xml of your Java web application:
 
 This filter should be added at the top of the web.xml so that it is invoked before other filters.
 
+Excluding Paths
+==========
+
 The servlet filter may be configured to exclude specific paths by specifying the **path-exclusion-prefix** init parameter. Requests to excluded paths are passed through the filter without inspecting headers.
 
-The values are a list of comma or whitespace separated values for prefixing endpoints to exclude.
-e.g. `/api/` will exclude `/api/some/endpoint/here` from the cors filter. It is recommended to have the both beginning and trailing / in your path exclusion pattern.
+Values specified via **path-exclusion-prefix** are a list of comma or whitespace separated values for prefixing endpoints to exclude.
+e.g. `/api/` will exclude `/api/some/endpoint/here` from the CORSFilter. If a path specified does not start with `/`, the slash will be added automatically.
+
 
 ````
 	<filter>
@@ -60,8 +64,8 @@ e.g. `/api/` will exclude `/api/some/endpoint/here` from the cors filter. It is 
 			<param-name>path-exclusion-prefix</param-name>
 			<param-value>
 				/api/one/
-				/api/two/
-				/other/api/
+				/api/two
+				other/api
 			</param-value>
 		</init-param>
 	</filter>
@@ -71,7 +75,22 @@ e.g. `/api/` will exclude `/api/some/endpoint/here` from the cors filter. It is 
 	</filter-mapping>
 ````
 
-In the example above, paths with the prefix as `/api/one/`, `api/two` and `other/api` would skip the header check.
+The paths specified in the **path-exclusion-prefix** must not contain the context path, as it is removed when checking the request URI.
+
+For example, with the above configuration and the context path `/path` the following HTTP requests would skip the header check:
+
+* `GET /path/api/one/example-suffix`
+* `GET /path/api/two`
+* `GET /path/api/two/with-suffix`
+* `POST /path/other/api-with-any-suffix`
+
+The following HTTP requests would not skip the header check:
+
+* `GET /path/api/one`
+* `GET /path/some/other/path`
+* `GET /path/`
+* `GET /path/some/other/api`
+* `DELETE /path/api/three`
 
 Building
 ========

--- a/README.md
+++ b/README.md
@@ -47,6 +47,26 @@ In the web.xml of your Java web application:
 
 This filter should be added at the top of the web.xml so that it is invoked before other filters.
 
+You may also whitelist the endpoints to exclude from the CORS filter by adding the param-name **path-exclusion-pattern**
+The values are a list of comma, period, semicolon, and newline separated values for prefixing endpoints to exclude.
+e.g. /api/ will exclude /api/some/endpoint/here from the cors filter. It is recommended to have the both beginning and trailing / in your path exclusion pattern.
+
+````
+	<filter>
+		<filter-name>CORSFilter</filter-name>
+		<filter-class>com.tasktop.servlet.cors.CorsHeaderScrutinyServletFilter</filter-class>
+		<init-param>
+		  <param-name>path-exclusion-pattern</param-name>
+		  <param-value>/api/</param-value>
+		</init-param>
+	</filter>
+	<filter-mapping>
+		<filter-name>CORSFilter</filter-name>
+		<url-pattern>/*</url-pattern>
+	</filter-mapping>
+````
+
+
 Building
 ========
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ In the web.xml of your Java web application:
 This filter should be added at the top of the web.xml so that it is invoked before other filters.
 
 You may also whitelist the endpoints to exclude from the CORS filter by adding the param-name **path-exclusion-pattern**
-The values are a list of comma, period, semicolon, and newline separated values for prefixing endpoints to exclude.
+The values are a list of comma or whitespace separated values for prefixing endpoints to exclude.
 e.g. /api/ will exclude /api/some/endpoint/here from the cors filter. It is recommended to have the both beginning and trailing / in your path exclusion pattern.
 
 ````

--- a/pom.xml
+++ b/pom.xml
@@ -68,11 +68,6 @@
       <version>1.10.19</version>
       <scope>test</scope>
     </dependency>
-      <dependency>
-          <groupId>org.slf4j</groupId>
-          <artifactId>slf4j-api</artifactId>
-          <version>1.7.5</version>
-      </dependency>
   </dependencies>
 
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -68,6 +68,11 @@
       <version>1.10.19</version>
       <scope>test</scope>
     </dependency>
+      <dependency>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-api</artifactId>
+          <version>1.7.5</version>
+      </dependency>
   </dependencies>
 
   <build>

--- a/src/main/java/com/tasktop/servlet/cors/ConfigurationParameterParser.java
+++ b/src/main/java/com/tasktop/servlet/cors/ConfigurationParameterParser.java
@@ -1,0 +1,28 @@
+package com.tasktop.servlet.cors;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+public class ConfigurationParameterParser {
+	private static final String PATH_DELIMITER_PATTERN = "[,\\s]+";
+	
+	static List<String> parseExclusionPaths(String paths) {
+		return Arrays.asList(paths.split(PATH_DELIMITER_PATTERN))
+				.stream()
+				.map(String::trim)
+				.filter(s -> !s.isEmpty())
+				.map(prependSlashIfNotPresent())
+				.collect(Collectors.toList());
+	}
+
+	private static Function<String, String> prependSlashIfNotPresent() {
+		return path -> {
+			if(path.startsWith("/")) {
+				return path;
+			}
+			return "/" + path;
+		};
+	}
+}

--- a/src/main/java/com/tasktop/servlet/cors/CorsHeaderScrutinyServletFilter.java
+++ b/src/main/java/com/tasktop/servlet/cors/CorsHeaderScrutinyServletFilter.java
@@ -47,13 +47,13 @@ public class CorsHeaderScrutinyServletFilter implements Filter {
 	private static final String HEADER_ORIGIN = "Origin";
 	private static final String HEADER_REFERER = "Referer";
 	
-	static final String EXCLUDE_HEADER_CHECK_PARAM = "exclude-header-check";
+	static final String PATH_EXCLUSION_PATTERN = "path-exclusion-pattern";
 	
 	Optional<RequestExclusionMatcher> requestExclusionMatcher = Optional.empty();
 
 	@Override
 	public void init(FilterConfig filterConfig) throws ServletException {
-		requestExclusionMatcher = Optional.ofNullable(filterConfig.getInitParameter(EXCLUDE_HEADER_CHECK_PARAM))
+		requestExclusionMatcher = Optional.ofNullable(filterConfig.getInitParameter(PATH_EXCLUSION_PATTERN))
 				.map(RequestExclusionMatcher::new);
 	}
 	

--- a/src/main/java/com/tasktop/servlet/cors/CorsHeaderScrutinyServletFilter.java
+++ b/src/main/java/com/tasktop/servlet/cors/CorsHeaderScrutinyServletFilter.java
@@ -39,13 +39,14 @@ public class CorsHeaderScrutinyServletFilter implements Filter {
 	private static final String HEADER_ORIGIN = "Origin";
 	private static final String HEADER_REFERER = "Referer";
 	
-	static final String PATH_EXCLUSION_PATTERN = "path-exclusion-prefix";
+	static final String INIT_PARAM_NAME_PATH_EXCLUSION_PREFIX = "path-exclusion-prefix";
 	
-	Optional<RequestPathMatcher> requestExclusionMatcher = Optional.empty();
+	private Optional<RequestPathMatcher> requestExclusionMatcher = Optional.empty();
 
 	@Override
 	public void init(FilterConfig filterConfig) throws ServletException {
-		requestExclusionMatcher = Optional.ofNullable(filterConfig.getInitParameter(PATH_EXCLUSION_PATTERN))
+		requestExclusionMatcher = Optional.ofNullable(filterConfig.getInitParameter(INIT_PARAM_NAME_PATH_EXCLUSION_PREFIX))
+				.map(ConfigurationParameterParser::parseExclusionPaths)
 				.map(RequestPathMatcher::new);
 	}
 	

--- a/src/main/java/com/tasktop/servlet/cors/CorsHeaderScrutinyServletFilter.java
+++ b/src/main/java/com/tasktop/servlet/cors/CorsHeaderScrutinyServletFilter.java
@@ -134,11 +134,8 @@ public class CorsHeaderScrutinyServletFilter implements Filter {
 	
 	class RequestExclusionMatcher {
 		private static final String PATTERN_OR = "|";
-		
 		private static final String PATTERN_PREFIX = "^";
-		
 		private static final String PATTERN_SUFFIX = "(/|$)";
-		
 		private static final String PATH_DELIMITER_PATTERN = "[,\\s]";
 		
 		private final Pattern acceptPattern;

--- a/src/main/java/com/tasktop/servlet/cors/RequestPathMatcher.java
+++ b/src/main/java/com/tasktop/servlet/cors/RequestPathMatcher.java
@@ -5,34 +5,34 @@ import static java.util.stream.Collectors.joining;
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
+import java.util.function.Function;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 
 import javax.servlet.http.HttpServletRequest;
 
 class RequestPathMatcher {
 	private static final String PATTERN_OR = "|";
 	private static final String PATTERN_PREFIX = "^";
-	private static final String PATTERN_SUFFIX = "(/|$)";
-	private static final String PATH_DELIMITER_PATTERN = "[,\\s]+";
 	
 	private final Pattern pathPattern;
-	
-	private List<String> paths = Collections.emptyList();
-	
-	RequestPathMatcher(String headerCheckPaths) {
-		this.paths = splitParameterToPathPatterns(headerCheckPaths);
 		
-		String urlExclusionRegex = paths.stream().map(this::decodePath).map(Pattern::quote).collect(joining(PATTERN_OR));
-		this.pathPattern = Pattern.compile(PATTERN_PREFIX + urlExclusionRegex + PATTERN_SUFFIX);
+	RequestPathMatcher(List<String> paths) {
+		String urlExclusionRegex = paths.stream()
+			.map(this::decodePath)
+			.map(Pattern::quote)
+			.map(addPatternPrefix())
+			.collect(joining(PATTERN_OR));
+		
+		this.pathPattern = Pattern.compile(urlExclusionRegex);
+	}
+
+	private Function<String, String> addPatternPrefix() {
+		return pattern -> PATTERN_PREFIX + pattern;
 	}
 
 	boolean matchesRequest(HttpServletRequest request) {
-		String requestPath = decodePath(getRequestUriWithoutContextPath(request));
-		return pathPattern.matcher(requestPath).find();
+		return pathPattern.matcher(getRequestUriWithoutContextPath(request)).find();
 	}
 	
 	private String decodePath(String path) {
@@ -44,19 +44,6 @@ class RequestPathMatcher {
 	}
 	
 	private String getRequestUriWithoutContextPath(HttpServletRequest request) {
-		String requestURI = request.getRequestURI(); 
-		return requestURI.substring(request.getContextPath().length());
-	}
-	
-	private List<String> splitParameterToPathPatterns(String value) {
-		return Arrays.asList(value.split(PATH_DELIMITER_PATTERN))
-				.stream()
-				.map(String::trim)
-				.filter(s -> !s.isEmpty())
-				.collect(Collectors.toList());
-	}
-	
-	List<String> getPaths() {
-		return this.paths;
+		return decodePath(request.getRequestURI()).substring(decodePath(request.getContextPath()).length());
 	}
 }

--- a/src/main/java/com/tasktop/servlet/cors/RequestPathMatcher.java
+++ b/src/main/java/com/tasktop/servlet/cors/RequestPathMatcher.java
@@ -1,0 +1,62 @@
+package com.tasktop.servlet.cors;
+
+import static java.util.stream.Collectors.joining;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import javax.servlet.http.HttpServletRequest;
+
+class RequestPathMatcher {
+	private static final String PATTERN_OR = "|";
+	private static final String PATTERN_PREFIX = "^";
+	private static final String PATTERN_SUFFIX = "(/|$)";
+	private static final String PATH_DELIMITER_PATTERN = "[,\\s]+";
+	
+	private final Pattern pathPattern;
+	
+	private List<String> paths = Collections.emptyList();
+	
+	RequestPathMatcher(String headerCheckPaths) {
+		this.paths = splitParameterToPathPatterns(headerCheckPaths);
+		
+		String urlExclusionRegex = paths.stream().map(this::decodePath).map(Pattern::quote).collect(joining(PATTERN_OR));
+		this.pathPattern = Pattern.compile(PATTERN_PREFIX + urlExclusionRegex + PATTERN_SUFFIX);
+	}
+
+	boolean matchesRequest(HttpServletRequest request) {
+		String requestPath = decodePath(getRequestUriWithoutContextPath(request));
+		return pathPattern.matcher(requestPath).find();
+	}
+	
+	private String decodePath(String path) {
+		try {
+			return URLDecoder.decode(path, StandardCharsets.UTF_8.name());
+		} catch (UnsupportedEncodingException e) {
+			throw new RuntimeException(e);
+		}
+	}
+	
+	private String getRequestUriWithoutContextPath(HttpServletRequest request) {
+		String requestURI = request.getRequestURI(); 
+		return requestURI.substring(request.getContextPath().length());
+	}
+	
+	private List<String> splitParameterToPathPatterns(String value) {
+		return Arrays.asList(value.split(PATH_DELIMITER_PATTERN))
+				.stream()
+				.map(String::trim)
+				.filter(s -> !s.isEmpty())
+				.collect(Collectors.toList());
+	}
+	
+	List<String> getPaths() {
+		return this.paths;
+	}
+}

--- a/src/test/java/com/tasktop/servlet/cors/ConfigurationParameterParserTest.java
+++ b/src/test/java/com/tasktop/servlet/cors/ConfigurationParameterParserTest.java
@@ -1,0 +1,41 @@
+package com.tasktop.servlet.cors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Test;
+
+public class ConfigurationParameterParserTest {
+	@Test
+	public void parseExclusionParameterEmptyString() {
+		assertThat(ConfigurationParameterParser.parseExclusionPaths("")).isEmpty();
+	}
+	
+	@Test 
+	public void parseExclusionParameterWithSinglePath() {
+		assertThat(ConfigurationParameterParser.parseExclusionPaths("/some/path")).containsExactly("/some/path");
+	}
+
+	@Test
+	public void parseExclusionParameterWithCommaSeparatedPaths() {
+		assertThat(ConfigurationParameterParser.parseExclusionPaths("/some/path,/other/different/path"))
+			.containsExactlyInAnyOrder("/some/path", "/other/different/path");
+	}
+	
+	@Test
+	public void parseExclusionParameterWithWhitespaceSeparatedPaths() {
+		assertThat(ConfigurationParameterParser.parseExclusionPaths("/some/path /other/different/path"))
+			.containsExactlyInAnyOrder("/some/path", "/other/different/path");
+	}
+	
+	@Test
+	public void parseExclusionParameterWithMultipleMixedDelimitersSeparatedPaths() {
+		assertThat(ConfigurationParameterParser.parseExclusionPaths("/first/path, /second/path\t/third/path\n\t\n/fourth/path   \t "))
+			.containsExactlyInAnyOrder("/first/path", "/second/path", "/third/path", "/fourth/path");
+	}
+	
+	@Test
+	public void parseExclusionParameterPrependsSlashIfNotPresent() {
+		assertThat(ConfigurationParameterParser.parseExclusionPaths("/some/path,other/different/path"))
+		.containsExactlyInAnyOrder("/some/path", "/other/different/path");
+	}
+}

--- a/src/test/java/com/tasktop/servlet/cors/CorsHeaderScrutinyServletFilterTest.java
+++ b/src/test/java/com/tasktop/servlet/cors/CorsHeaderScrutinyServletFilterTest.java
@@ -9,7 +9,9 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.regex.Pattern;
 
 import javax.servlet.FilterChain;
 import javax.servlet.FilterConfig;
@@ -21,6 +23,7 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+import org.junit.runners.Parameterized;
 
 public class CorsHeaderScrutinyServletFilterTest {
 
@@ -43,14 +46,19 @@ public class CorsHeaderScrutinyServletFilterTest {
 
 	private final FilterChain chain = mock(FilterChain.class);
 
+	private final FilterConfig config = mock(FilterConfig.class);
+
+
 	@Before
 	public void before() {
 		doReturn(Collections.emptyEnumeration()).when(request).getHeaders(any());
+		doReturn("http://nowhere.com/endpoint").when(request).getRequestURI();
+		doReturn("endpoint").when(request).getContextPath();
 	}
 
 	@Test
 	public void init() throws ServletException {
-		filter.init(mock(FilterConfig.class));
+		filter.init(config);
 	}
 
 	@Test
@@ -60,31 +68,26 @@ public class CorsHeaderScrutinyServletFilterTest {
 
 	@Test
 	public void doFilterAcceptsRequestWithoutOriginOrReferer() throws IOException, ServletException {
-		filter.doFilter(request, response, chain);
-		verify(chain).doFilter(request, response);
-		verifyNoMoreInteractions(chain);
+		verifyDoFilterAcceptsRequest();
 	}
 
 	@Test
 	public void doFilterRejectsRequestWithEmptyOrigin() throws IOException, ServletException {
 		mockHeader(HTTP_HEADER_ORIGIN, "");
-		filter.doFilter(request, response, chain);
-		expectForbidden();
+		verifyDoFilterRejectsRequest();
 	}
 
 	@Test
 	public void doFilterRejectsRequestWithOriginWithoutHost() throws IOException, ServletException {
 		mockHeader(HTTP_HEADER_ORIGIN, "http://a-host");
-		filter.doFilter(request, response, chain);
-		expectForbidden();
+		verifyDoFilterRejectsRequest();
 	}
 
 	@Test
 	public void doFilterRejectsRequestWithOriginWithDifferentHost() throws IOException, ServletException {
 		mockHeader(HTTP_HEADER_ORIGIN, "http://a-host");
 		mockHeader(HTTP_HEADER_HOST, "a-different-host");
-		filter.doFilter(request, response, chain);
-		expectForbidden();
+		verifyDoFilterRejectsRequest();
 	}
 
 	@Test
@@ -93,9 +96,7 @@ public class CorsHeaderScrutinyServletFilterTest {
 		mockHeader(HTTP_HEADER_ORIGIN, "http://a-host");
 		mockHeader(HTTP_HEADER_HOST, "a-different-host");
 		mockHeader(HTTP_HEADER_X_FORWARDED_HOST, "a-host");
-		filter.doFilter(request, response, chain);
-		verify(chain).doFilter(request, response);
-		verifyNoMoreInteractions(chain);
+		verifyDoFilterAcceptsRequest();
 	}
 
 	@Test
@@ -104,81 +105,68 @@ public class CorsHeaderScrutinyServletFilterTest {
 		mockHeader(HTTP_HEADER_ORIGIN, "http://a-host");
 		mockHeader(HTTP_HEADER_HOST, "a-host");
 		mockHeader(HTTP_HEADER_X_FORWARDED_HOST, "a-different-host");
-		filter.doFilter(request, response, chain);
-		expectForbidden();
+		verifyDoFilterRejectsRequest();
 	}
 
 	@Test
 	public void doFilterRejectsRequestWithOriginWithEmptyHost() throws IOException, ServletException {
 		mockHeader(HTTP_HEADER_ORIGIN, "http://");
 		mockHeader(HTTP_HEADER_HOST, "");
-		filter.doFilter(request, response, chain);
-		expectForbidden();
+		verifyDoFilterRejectsRequest();
 	}
 
 	@Test
 	public void doFilterRejectsRequestWithMultipleOriginHeadersWithMatchingHost() throws IOException, ServletException {
 		mockHeader(HTTP_HEADER_ORIGIN, "http://a-host", "http://a-different-host");
 		mockHeader(HTTP_HEADER_HOST, "a-host");
-		filter.doFilter(request, response, chain);
-		expectForbidden();
+		verifyDoFilterRejectsRequest();
 	}
 
 	@Test
 	public void doFilterAcceptsRequestWithMatchingOrigin() throws IOException, ServletException {
 		mockHeader(HTTP_HEADER_ORIGIN, "http://a-host");
 		mockHeader(HTTP_HEADER_HOST, "a-host");
-		filter.doFilter(request, response, chain);
-		verify(chain).doFilter(request, response);
-		verifyNoMoreInteractions(chain);
+		verifyDoFilterAcceptsRequest();
 	}
 
 	@Test
 	public void doFilterAcceptsRequestWithMatchingOriginAndPort() throws IOException, ServletException {
 		mockHeader(HTTP_HEADER_ORIGIN, "http://a-host:8080");
 		mockHeader(HTTP_HEADER_HOST, "a-host:8080");
-		filter.doFilter(request, response, chain);
-		verify(chain).doFilter(request, response);
-		verifyNoMoreInteractions(chain);
+		verifyDoFilterAcceptsRequest();
 	}
 
 	@Test
 	public void doFilterAcceptsRequestWithMatchingOriginAndDifferentPort() throws IOException, ServletException {
 		mockHeader(HTTP_HEADER_ORIGIN, "http://a-host:9999");
 		mockHeader(HTTP_HEADER_HOST, "a-host:8080");
-		filter.doFilter(request, response, chain);
-		verify(chain).doFilter(request, response);
-		verifyNoMoreInteractions(chain);
+		verifyDoFilterAcceptsRequest();
 	}
 
 	@Test
 	public void doFilterRejectsRequestWithEmptyReferer() throws IOException, ServletException {
 		mockHeader(HTTP_HEADER_REFERER, "");
-		filter.doFilter(request, response, chain);
-		expectForbidden();
+		verifyDoFilterRejectsRequest();
 	}
 
 	@Test
 	public void doFilterRejectsRequestWithRefererWithoutHost() throws IOException, ServletException {
 		mockHeader(HTTP_HEADER_REFERER, "http://a-host/some/path");
-		filter.doFilter(request, response, chain);
-		expectForbidden();
+		verifyDoFilterRejectsRequest();
 	}
 
 	@Test
 	public void doFilterRejectsRequestWithRefererWithDifferentHost() throws IOException, ServletException {
 		mockHeader(HTTP_HEADER_REFERER, "http://a-host/some/path");
 		mockHeader(HTTP_HEADER_HOST, "a-different-host");
-		filter.doFilter(request, response, chain);
-		expectForbidden();
+		verifyDoFilterRejectsRequest();
 	}
 
 	@Test
 	public void doFilterRejectsRequestWithRefererWithEmptyHost() throws IOException, ServletException {
 		mockHeader(HTTP_HEADER_REFERER, "/a-path");
 		mockHeader(HTTP_HEADER_HOST, "");
-		filter.doFilter(request, response, chain);
-		expectForbidden();
+		verifyDoFilterRejectsRequest();
 	}
 
 	@Test
@@ -186,17 +174,14 @@ public class CorsHeaderScrutinyServletFilterTest {
 			throws IOException, ServletException {
 		mockHeader(HTTP_HEADER_REFERER, "http://a-host", "http://a-host");
 		mockHeader(HTTP_HEADER_HOST, "a-host");
-		filter.doFilter(request, response, chain);
-		expectForbidden();
+		verifyDoFilterRejectsRequest();
 	}
 
 	@Test
 	public void doFilterAcceptsRequestWithMatchingReferer() throws IOException, ServletException {
 		mockHeader(HTTP_HEADER_REFERER, "http://a-host/some/path");
 		mockHeader(HTTP_HEADER_HOST, "a-host");
-		filter.doFilter(request, response, chain);
-		verify(chain).doFilter(request, response);
-		verifyNoMoreInteractions(chain);
+		verifyDoFilterAcceptsRequest();
 	}
 
 	@Test
@@ -204,9 +189,18 @@ public class CorsHeaderScrutinyServletFilterTest {
 		mockHeader(HTTP_HEADER_REFERER, "http://a-host/some/path");
 		mockHeader(HTTP_HEADER_ORIGIN, "http://a-host");
 		mockHeader(HTTP_HEADER_HOST, "a-host");
+		verifyDoFilterAcceptsRequest();
+	}
+
+	private void verifyDoFilterAcceptsRequest() throws IOException, ServletException {
 		filter.doFilter(request, response, chain);
 		verify(chain).doFilter(request, response);
 		verifyNoMoreInteractions(chain);
+	}
+
+	private void verifyDoFilterRejectsRequest() throws IOException, ServletException {
+		filter.doFilter(request, response, chain);
+		expectForbidden();
 	}
 
 	private void expectForbidden() throws IOException {

--- a/src/test/java/com/tasktop/servlet/cors/CorsHeaderScrutinyServletFilterTest.java
+++ b/src/test/java/com/tasktop/servlet/cors/CorsHeaderScrutinyServletFilterTest.java
@@ -304,7 +304,7 @@ public class CorsHeaderScrutinyServletFilterTest {
 	}
 	
 	private FilterConfig configWithExlusionPathAs(String path) {
-		doReturn(path).when(config).getInitParameter(CorsHeaderScrutinyServletFilter.EXCLUDE_HEADER_CHECK_PARAM);
+		doReturn(path).when(config).getInitParameter(CorsHeaderScrutinyServletFilter.PATH_EXCLUSION_PATTERN);
 		return config;
 	}
 	

--- a/src/test/java/com/tasktop/servlet/cors/CorsHeaderScrutinyServletFilterTest.java
+++ b/src/test/java/com/tasktop/servlet/cors/CorsHeaderScrutinyServletFilterTest.java
@@ -226,7 +226,7 @@ public class CorsHeaderScrutinyServletFilterTest {
 	}
 	
 	private FilterConfig configWithExlusionPathAs(String path) {
-		doReturn(path).when(config).getInitParameter(CorsHeaderScrutinyServletFilter.PATH_EXCLUSION_PATTERN);
+		doReturn(path).when(config).getInitParameter(CorsHeaderScrutinyServletFilter.INIT_PARAM_NAME_PATH_EXCLUSION_PREFIX);
 		return config;
 	}
 

--- a/src/test/java/com/tasktop/servlet/cors/CorsHeaderScrutinyServletFilterTest.java
+++ b/src/test/java/com/tasktop/servlet/cors/CorsHeaderScrutinyServletFilterTest.java
@@ -13,7 +13,7 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.List;
+import java.util.Optional;
 
 import javax.servlet.FilterChain;
 import javax.servlet.FilterConfig;
@@ -58,38 +58,13 @@ public class CorsHeaderScrutinyServletFilterTest {
 	@Test
 	public void initWithNoHeaderCheckExclusionParam() throws ServletException {
 		filter.init(config);
+		assertThat(filter.getRequestExclusionMatcher()).isEmpty();
 	}
 	
 	@Test
-	public void initWithEmptyHeaderCheckExclusionPath() throws ServletException {
-		filter.init(configWithExlusionPathAs(""));
-		
-		assertThat(getExcludePathsChecked()).isEmpty();
-	}
-	
-	@Test 
-	public void initWithSingleHeaderCheckExclusionPath() throws ServletException {
-		filter.init(configWithExlusionPathAs("/some/path"));
-		assertThat(getExcludePathsChecked()).containsExactly("/some/path");
-	}
-
-	@Test
-	public void initWithCommaSeparatedHeaderCheckExclusionPath() throws ServletException {
-		filter.init(configWithExlusionPathAs("/some/path,/other/different/path"));
-		assertThat(getExcludePathsChecked()).containsExactlyInAnyOrder("/some/path", "/other/different/path");
-	}
-	
-	@Test
-	public void initWithWhitespaceSeparatedHeaderCheckExclusionPath() throws ServletException {
-		filter.init(configWithExlusionPathAs("/some/path /other/different/path"));
-		assertThat(getExcludePathsChecked()).containsExactlyInAnyOrder("/some/path", "/other/different/path");
-	}
-	
-	@Test
-	public void initWithMultipleMixedDelimitersSeparatedHeaderCheckExclusionPath() throws ServletException {
-		filter.init(configWithExlusionPathAs("/first/path, /second/path\t/third/path\n\n/fourth/path   \t "));
-		assertThat(getExcludePathsChecked())
-			.containsExactlyInAnyOrder("/first/path", "/second/path", "/third/path", "/fourth/path");
+	public void initWithHeaderCheckExclusionPath() throws ServletException {
+		filter.init(configWithExlusionPathAs("some/path"));
+		assertThat(filter.getRequestExclusionMatcher()).isNotEmpty();
 	}
 
 	@Test
@@ -224,93 +199,35 @@ public class CorsHeaderScrutinyServletFilterTest {
 	}
 	
 	@Test
-	public void doFilterSkipsHeaderCheckWhenRequestWithinExclusionPattern() throws IOException, ServletException {
-		mockRequest("endpoint", "somewhere");
-		filter.init(configWithExlusionPathAs("/somewhere"));
-		verifyDoFilterAcceptsRequest();
+	public void doFilterSkipsHeaderCheckWhenExclusionIsAllowed() throws IOException, ServletException {
+		RequestPathMatcher matchAllRequests = mock(RequestPathMatcher.class);
+		doReturn(true).when(matchAllRequests).matchesRequest(any());
+		
+		CorsHeaderScrutinyServletFilter filter = createFilterWithPathMatcher(matchAllRequests);
+		
+		filter.doFilter(request, response, chain);
+		verify(chain).doFilter(request, response);
+		verifyNoMoreInteractions(chain);
 		verifyHeaderCheckSkipped();
 	}
 	
 	@Test
-	public void doFilterChecksHeaderWhenRequestNotInExclusionPattern() throws IOException, ServletException {
-		mockRequest("endpoint", "somewhere");
-		filter.init(configWithExlusionPathAs("/other"));
-		verifyDoFilterAcceptsRequest();
-		verify(request, atLeastOnce()).getHeaders(any());
-	}
-	
-	@Test
-	public void doFilterChecksHeaderWhenRequestContainsExclusionPattern() throws IOException, ServletException {
-		mockRequest("endpoint", "somewhere");
-		filter.init(configWithExlusionPathAs("/some"));
-		verifyDoFilterAcceptsRequest();
-		verify(request, atLeastOnce()).getHeaders(any());
-	}
-	
-	@Test
-	public void doFilterChecksHeaderWhenRequestContainedOnStartOfExclusionPattern() throws IOException, ServletException {
-		mockRequest("endpoint", "somewhere");
-		filter.init(configWithExlusionPathAs("/somewhereelse"));
-		verifyDoFilterAcceptsRequest();
-		verify(request, atLeastOnce()).getHeaders(any());
-	}
-	
-	@Test
-	public void doFilterChecksHeaderWhenRequestContainedOnEndOfExclusionPattern() throws IOException, ServletException {
-		mockRequest("endpoint", "somewhere");
-		filter.init(configWithExlusionPathAs("/elsesomewhere"));
-		verifyDoFilterAcceptsRequest();
-		verify(request, atLeastOnce()).getHeaders(any());
-	}
-	
-	@Test
-	public void doFilterChecksHeaderWhenRequestDoesNotStartWithExclusionPattern() throws IOException, ServletException {
-		mockRequest("endpoint", "somewhere");
-		filter.init(configWithExlusionPathAs("/else/somewhere"));
-		verifyDoFilterAcceptsRequest();
-		verify(request, atLeastOnce()).getHeaders(any());
-	}
-	
-	@Test
-	public void doFilterChecksHeaderWhenExclusionPatternMoreSpecificThanRequest() throws IOException, ServletException {
-		mockRequest("endpoint", "somewhere");
-		filter.init(configWithExlusionPathAs("/somewhere/else"));
-		verifyDoFilterAcceptsRequest();
-		verify(request, atLeastOnce()).getHeaders(any());
-	}
-	
-	@Test
-	public void doFilterSkipsHeaderCheckWhenRequestMoreSpecificExclusionPattern() throws IOException, ServletException {
-		mockRequest("endpoint", "somewhere/else/specifically");
-		filter.init(configWithExlusionPathAs("/somewhere/else"));
-		verifyDoFilterAcceptsRequest();
-		verify(request, never()).getHeaders(any());
-	}
-	
-	@Test
-	public void doFilterSkipsHeaderCheckWhenPercentEncodedRequestMatchesExclusionPattern() throws IOException, ServletException {
-		mockRequest("endpoint", "somewhere/%C3%A9");
-		filter.init(configWithExlusionPathAs("/somewhere/é"));
-		verifyDoFilterAcceptsRequest();
-		verify(request, never()).getHeaders(any());
-	}
-	
-	@Test
-	public void doFilterChecksHeaderWhenPercentEncodedRequestDoesNotMatchExclusionPattern() throws IOException, ServletException {
-		mockRequest("endpoint", "somewhere/%C3%A9");
-		filter.init(configWithExlusionPathAs("/somewhere/élse"));
-		verifyDoFilterAcceptsRequest();
+	public void doFilterPerformsHeaderCheckWhenExclusionIsNotAllowed() throws IOException, ServletException {
+		RequestPathMatcher matchNoRequests = mock(RequestPathMatcher.class);
+		doReturn(false).when(matchNoRequests).matchesRequest(any());
+		
+		CorsHeaderScrutinyServletFilter filter = createFilterWithPathMatcher(matchNoRequests);
+		
+		filter.doFilter(request, response, chain);
+		verify(chain).doFilter(request, response);
+		verifyNoMoreInteractions(chain);
+		
 		verify(request, atLeastOnce()).getHeaders(any());
 	}
 	
 	private FilterConfig configWithExlusionPathAs(String path) {
 		doReturn(path).when(config).getInitParameter(CorsHeaderScrutinyServletFilter.PATH_EXCLUSION_PATTERN);
 		return config;
-	}
-	
-	private List<String> getExcludePathsChecked() {
-		assertThat(filter.getRequestExclusionMatcher()).isNotEmpty();
-		return filter.getRequestExclusionMatcher().get().getExcludePaths();
 	}
 
 	private void verifyDoFilterAcceptsRequest() throws IOException, ServletException {
@@ -339,8 +256,12 @@ public class CorsHeaderScrutinyServletFilterTest {
 		doAnswer(i -> Collections.enumeration(Arrays.asList(values))).when(request).getHeaders(headerName);
 	}
 	
-	private void mockRequest(String contextPath, String requestURI) {
-		doReturn(contextPath).when(request).getContextPath();
-		doReturn(contextPath + "/" + requestURI).when(request).getRequestURI();
+	private CorsHeaderScrutinyServletFilter createFilterWithPathMatcher(RequestPathMatcher matcher) {
+		return  new CorsHeaderScrutinyServletFilter() {
+			@Override
+			Optional<RequestPathMatcher> getRequestExclusionMatcher() {
+				return Optional.of(matcher);
+			}
+		};
 	}
 }

--- a/src/test/java/com/tasktop/servlet/cors/RequestPathMatcherTest.java
+++ b/src/test/java/com/tasktop/servlet/cors/RequestPathMatcherTest.java
@@ -4,7 +4,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 
-import javax.servlet.ServletException;
+import java.util.Arrays;
+
 import javax.servlet.http.HttpServletRequest;
 
 import org.junit.Test;
@@ -13,112 +14,91 @@ public class RequestPathMatcherTest {
 	private RequestPathMatcher requestMatcher;
 	
 	@Test
-	public void createWithEmptyString() throws ServletException {
-		requestMatcher = new RequestPathMatcher("");
-		assertThat(requestMatcher.getPaths()).isEmpty();
-	}
-	
-	@Test 
-	public void createWithSinglePath() throws ServletException {
-		requestMatcher = new RequestPathMatcher("/some/path");
-		assertThat(requestMatcher.getPaths()).containsExactly("/some/path");
-	}
-
-	@Test
-	public void createWithCommaSeparatedPaths() throws ServletException {
-		requestMatcher = new RequestPathMatcher("/some/path,/other/different/path");
-		assertThat(requestMatcher.getPaths()).containsExactlyInAnyOrder("/some/path", "/other/different/path");
-	}
-	
-	@Test
-	public void createWithWhitespaceSeparatedPaths() throws ServletException {
-		requestMatcher = new RequestPathMatcher("/some/path /other/different/path");
-		assertThat(requestMatcher.getPaths()).containsExactlyInAnyOrder("/some/path", "/other/different/path");
-	}
-	
-	@Test
-	public void createWithMultipleMixedDelimitersSeparatedPaths() throws ServletException {
-		requestMatcher = new RequestPathMatcher("/first/path, /second/path\t/third/path\n\t\n/fourth/path   \t ");
-		assertThat(requestMatcher.getPaths())
-			.containsExactlyInAnyOrder("/first/path", "/second/path", "/third/path", "/fourth/path");
-	}
-	
-	@Test
 	public void matchesRequestWithinPathList() {
-		requestMatcher = new RequestPathMatcher("/somewhere");
+		requestMatcher = createRequestPathMatcher("/somewhere");
 		assertMatchesRequest(mockRequest("endpoint", "somewhere"));
 	}
 	
 	@Test
-	public void doesNotMatchRequestNotWithinPathList() {
-		requestMatcher = new RequestPathMatcher("/other");
+	public void doesNotMatchRequestWithRootPathIfPatternDefinedForSpecificPaths() {
+		requestMatcher = createRequestPathMatcher("/somewhere/");
 		assertDoesNotMatchRequest(mockRequest("endpoint", "somewhere"));
 	}
 	
 	@Test
-	public void doesNotMatchRequestWhenPathPartiallyInPathList() {
-		requestMatcher = new RequestPathMatcher("/some");
+	public void doesNotMatchRequestNotWithinPathList() {
+		requestMatcher = createRequestPathMatcher("/other");
 		assertDoesNotMatchRequest(mockRequest("endpoint", "somewhere"));
+	}
+	
+	@Test
+	public void matchesRequestWhenPathPartiallyInPathList() {
+		requestMatcher = createRequestPathMatcher("/some");
+		assertMatchesRequest(mockRequest("endpoint", "somewhere"));
 	}
 	
 	@Test
 	public void doesNotMatchRequestWhenPathOnStartOfPathList() {
-		requestMatcher = new RequestPathMatcher("/somewhereelse");
+		requestMatcher = createRequestPathMatcher("/somewhereelse");
 		assertDoesNotMatchRequest(mockRequest("endpoint", "somewhere"));
 	}
 	
 	@Test
 	public void doesNotMatchRequestWhenPathOnEndOfPathList() {
-		requestMatcher = new RequestPathMatcher("/elsesomewhere");
+		requestMatcher = createRequestPathMatcher("/elsesomewhere");
 		assertDoesNotMatchRequest(mockRequest("endpoint", "somewhere"));
 	}
 	
 	@Test
 	public void doesNotMatchRequestWhenPathDoesNotStartWithExcludedPaths() {
-		requestMatcher = new RequestPathMatcher("/else/somewhere");
+		requestMatcher = createRequestPathMatcher("/else/somewhere");
 		assertDoesNotMatchRequest(mockRequest("endpoint", "somewhere"));
 	}
 	
 	@Test
 	public void doesNotMatchRequestWhenPatternMoreSpecificThanRequest() {
-		requestMatcher = new RequestPathMatcher("/somewhere/else");
+		requestMatcher = createRequestPathMatcher("/somewhere/else");
 		assertDoesNotMatchRequest(mockRequest("endpoint", "somewhere"));
 	}
 	
 	@Test
 	public void matchesRequestWhenRequestMoreSpecificThanPattern() {
-		requestMatcher = new RequestPathMatcher("/somewhere/else");
+		requestMatcher = createRequestPathMatcher("/somewhere/else");
 		assertMatchesRequest(mockRequest("endpoint", "somewhere/else/specifically"));
 	}
 	
 	@Test
 	public void matchesRequestWhenPercentEncodedRequestMatchesPattern() {
-		requestMatcher = new RequestPathMatcher("/somewhere/é");
+		requestMatcher = createRequestPathMatcher("/somewhere/é");
 		assertMatchesRequest(mockRequest("endpoint", "somewhere/%C3%A9"));
 	}
 	
 	@Test
 	public void doesNotMatchRequestWhenPercentEncodedRequestNotInPattern() {
-		requestMatcher = new RequestPathMatcher("/somewhere/élse");
+		requestMatcher = createRequestPathMatcher("/somewhere/élse");
 		assertDoesNotMatchRequest(mockRequest("endpoint", "somewhere/%C3%A9"));
 	}
 	
 	@Test
 	public void matchesRequestWithSemanticallyEquivalentPathInPatternButDifferentEncodings() {
-		requestMatcher = new RequestPathMatcher("/a+space/");
+		requestMatcher = createRequestPathMatcher("/a+space/");
 		assertMatchesRequest(mockRequest("endpoint", "a%20space/"));
 	}
 	
 	@Test
 	public void matchesRequestWhenPathWithinMatcherPathList() {
-		requestMatcher = new RequestPathMatcher("\t\t/some/other/place\n\t\t\t/somewhere/else\n");
+		requestMatcher = createRequestPathMatcher("/some/other/place", "/somewhere/else");
 		assertMatchesRequest(mockRequest("endpoint", "somewhere/else/specifically"));
 	}
 	
 	@Test
 	public void doesNotMatchRequestWhenPathNotWithinMatcherPathList() {
-		requestMatcher = new RequestPathMatcher("\t\t/some/other/place\n\t\t\t/somewhere/else\n");
+		requestMatcher = createRequestPathMatcher("/some/other/place", "/somewhere/else");
 		assertDoesNotMatchRequest(mockRequest("endpoint", "somewhere/third/place"));
+	}
+	
+	private RequestPathMatcher createRequestPathMatcher(String... paths) {
+		return new RequestPathMatcher(Arrays.asList(paths));
 	}
 	
 	private void assertMatchesRequest(HttpServletRequest request) {

--- a/src/test/java/com/tasktop/servlet/cors/RequestPathMatcherTest.java
+++ b/src/test/java/com/tasktop/servlet/cors/RequestPathMatcherTest.java
@@ -1,0 +1,140 @@
+package com.tasktop.servlet.cors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+
+import org.junit.Test;
+
+public class RequestPathMatcherTest {
+	private RequestPathMatcher requestMatcher;
+	
+	@Test
+	public void createWithEmptyString() throws ServletException {
+		requestMatcher = new RequestPathMatcher("");
+		assertThat(requestMatcher.getPaths()).isEmpty();
+	}
+	
+	@Test 
+	public void createWithSinglePath() throws ServletException {
+		requestMatcher = new RequestPathMatcher("/some/path");
+		assertThat(requestMatcher.getPaths()).containsExactly("/some/path");
+	}
+
+	@Test
+	public void createWithCommaSeparatedPaths() throws ServletException {
+		requestMatcher = new RequestPathMatcher("/some/path,/other/different/path");
+		assertThat(requestMatcher.getPaths()).containsExactlyInAnyOrder("/some/path", "/other/different/path");
+	}
+	
+	@Test
+	public void createWithWhitespaceSeparatedPaths() throws ServletException {
+		requestMatcher = new RequestPathMatcher("/some/path /other/different/path");
+		assertThat(requestMatcher.getPaths()).containsExactlyInAnyOrder("/some/path", "/other/different/path");
+	}
+	
+	@Test
+	public void createWithMultipleMixedDelimitersSeparatedPaths() throws ServletException {
+		requestMatcher = new RequestPathMatcher("/first/path, /second/path\t/third/path\n\t\n/fourth/path   \t ");
+		assertThat(requestMatcher.getPaths())
+			.containsExactlyInAnyOrder("/first/path", "/second/path", "/third/path", "/fourth/path");
+	}
+	
+	@Test
+	public void matchesRequestWithinPathList() {
+		requestMatcher = new RequestPathMatcher("/somewhere");
+		assertMatchesRequest(mockRequest("endpoint", "somewhere"));
+	}
+	
+	@Test
+	public void doesNotMatchRequestNotWithinPathList() {
+		requestMatcher = new RequestPathMatcher("/other");
+		assertDoesNotMatchRequest(mockRequest("endpoint", "somewhere"));
+	}
+	
+	@Test
+	public void doesNotMatchRequestWhenPathPartiallyInPathList() {
+		requestMatcher = new RequestPathMatcher("/some");
+		assertDoesNotMatchRequest(mockRequest("endpoint", "somewhere"));
+	}
+	
+	@Test
+	public void doesNotMatchRequestWhenPathOnStartOfPathList() {
+		requestMatcher = new RequestPathMatcher("/somewhereelse");
+		assertDoesNotMatchRequest(mockRequest("endpoint", "somewhere"));
+	}
+	
+	@Test
+	public void doesNotMatchRequestWhenPathOnEndOfPathList() {
+		requestMatcher = new RequestPathMatcher("/elsesomewhere");
+		assertDoesNotMatchRequest(mockRequest("endpoint", "somewhere"));
+	}
+	
+	@Test
+	public void doesNotMatchRequestWhenPathDoesNotStartWithExcludedPaths() {
+		requestMatcher = new RequestPathMatcher("/else/somewhere");
+		assertDoesNotMatchRequest(mockRequest("endpoint", "somewhere"));
+	}
+	
+	@Test
+	public void doesNotMatchRequestWhenPatternMoreSpecificThanRequest() {
+		requestMatcher = new RequestPathMatcher("/somewhere/else");
+		assertDoesNotMatchRequest(mockRequest("endpoint", "somewhere"));
+	}
+	
+	@Test
+	public void matchesRequestWhenRequestMoreSpecificThanPattern() {
+		requestMatcher = new RequestPathMatcher("/somewhere/else");
+		assertMatchesRequest(mockRequest("endpoint", "somewhere/else/specifically"));
+	}
+	
+	@Test
+	public void matchesRequestWhenPercentEncodedRequestMatchesPattern() {
+		requestMatcher = new RequestPathMatcher("/somewhere/é");
+		assertMatchesRequest(mockRequest("endpoint", "somewhere/%C3%A9"));
+	}
+	
+	@Test
+	public void doesNotMatchRequestWhenPercentEncodedRequestNotInPattern() {
+		requestMatcher = new RequestPathMatcher("/somewhere/élse");
+		assertDoesNotMatchRequest(mockRequest("endpoint", "somewhere/%C3%A9"));
+	}
+	
+	@Test
+	public void matchesRequestWithSemanticallyEquivalentPathInPatternButDifferentEncodings() {
+		requestMatcher = new RequestPathMatcher("/a+space/");
+		assertMatchesRequest(mockRequest("endpoint", "a%20space/"));
+	}
+	
+	@Test
+	public void matchesRequestWhenPathWithinMatcherPathList() {
+		requestMatcher = new RequestPathMatcher("\t\t/some/other/place\n\t\t\t/somewhere/else\n");
+		assertMatchesRequest(mockRequest("endpoint", "somewhere/else/specifically"));
+	}
+	
+	@Test
+	public void doesNotMatchRequestWhenPathNotWithinMatcherPathList() {
+		requestMatcher = new RequestPathMatcher("\t\t/some/other/place\n\t\t\t/somewhere/else\n");
+		assertDoesNotMatchRequest(mockRequest("endpoint", "somewhere/third/place"));
+	}
+	
+	private void assertMatchesRequest(HttpServletRequest request) {
+		assertThat(requestMatcher.matchesRequest(request)).isTrue();
+	}
+	
+	private void assertDoesNotMatchRequest(HttpServletRequest request) {
+		assertThat(requestMatcher.matchesRequest(request)).isFalse();
+	}
+
+	private HttpServletRequest mockRequest(String contextPath, String requestURI) {
+		HttpServletRequest request = mock(HttpServletRequest.class);
+		
+		doReturn(contextPath).when(request).getContextPath();
+		doReturn(contextPath + "/" + requestURI).when(request).getRequestURI();
+		
+		return request;
+	}
+}


### PR DESCRIPTION
Provide a way for the user to specify a list of paths that don't need header checking. Added a init-param to the filter to provide the functionality.