### PR TITLE
support excluding requests from header checking

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,51 @@ In the web.xml of your Java web application:
 
 This filter should be added at the top of the web.xml so that it is invoked before other filters.
 
+Excluding Paths
+---------------
+
+The servlet filter may be configured to exclude requests on specific paths by specifying the **exclusion-paths** init parameter. Requests to excluded paths are passed through the filter without inspecting headers.
+
+Values specified via **exclusion-paths** are a list of comma or whitespace separated values for prefixing request paths to exclude.
+e.g. `/api/` will exclude `/api/some/endpoint/here` from the filter. If a path specified does not start with `/`, the slash will be added automatically.
+
+
+````
+	<filter>
+		<filter-name>CORSFilter</filter-name>
+		<filter-class>com.tasktop.servlet.cors.CorsHeaderScrutinyServletFilter</filter-class>
+		<init-param>
+			<param-name>exclusion-paths</param-name>
+			<param-value>
+				/api/one/
+				/api/two
+				other/api
+			</param-value>
+		</init-param>
+	</filter>
+	<filter-mapping>
+		<filter-name>CORSFilter</filter-name>
+		<url-pattern>/*</url-pattern>
+	</filter-mapping>
+````
+
+The paths specified in the **exclusion-paths** must not contain the context path, as it is removed when checking the request URI.
+
+For example, with the above configuration and the context path `/path` the following HTTP requests would skip the header check:
+
+* `GET /path/api/one/example-suffix`
+* `GET /path/api/two`
+* `GET /path/api/two/with-suffix`
+* `POST /path/other/api-with-any-suffix`
+
+The following HTTP requests would not skip the header check:
+
+* `GET /path/api/one`
+* `GET /path/some/other/path`
+* `GET /path/`
+* `GET /path/some/other/api`
+* `DELETE /path/api/three`
+
 Building
 ========
 

--- a/src/main/java/com/tasktop/servlet/cors/ConfigurationParameterParser.java
+++ b/src/main/java/com/tasktop/servlet/cors/ConfigurationParameterParser.java
@@ -1,0 +1,52 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Tasktop Technologies.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package com.tasktop.servlet.cors;
+
+import static java.text.MessageFormat.format;
+import static java.util.Objects.requireNonNull;
+import static java.util.stream.Collectors.toList;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Function;
+
+class ConfigurationParameterParser {
+	private static final String PATH_DELIMITER_PATTERN = "[,\\s]+";
+
+	public static List<String> parseExclusionPaths(String paths) {
+		requireNonNull(paths);
+		List<String> values = Arrays.asList(paths.split(PATH_DELIMITER_PATTERN)).stream().map(String::trim)
+				.filter(s -> !s.isEmpty()).map(prependSlashIfNotPresent()).collect(toList());
+		if (values.isEmpty()) {
+			throw new IllegalArgumentException(
+					format("When specified, {0} must have at least one value", InitParameterNames.EXCLUSION_PATHS));
+		}
+		return values;
+	}
+
+	private static Function<String, String> prependSlashIfNotPresent() {
+		return path -> {
+			if (path.startsWith("/")) {
+				return path;
+			}
+			return "/" + path;
+		};
+	}
+
+	private ConfigurationParameterParser() {
+		// prevent instantiation
+	}
+}

--- a/src/main/java/com/tasktop/servlet/cors/InitParameterNames.java
+++ b/src/main/java/com/tasktop/servlet/cors/InitParameterNames.java
@@ -15,11 +15,11 @@
  *******************************************************************************/
 package com.tasktop.servlet.cors;
 
-class ForbiddenException extends RuntimeException {
+class InitParameterNames {
 
-	private static final long serialVersionUID = 1L;
+	public static final String EXCLUSION_PATHS = "exclusion-paths";
 
-	ForbiddenException(String message) {
-		super(message);
+	private InitParameterNames() {
+		// prevent instantiation
 	}
 }

--- a/src/main/java/com/tasktop/servlet/cors/Preconditions.java
+++ b/src/main/java/com/tasktop/servlet/cors/Preconditions.java
@@ -15,11 +15,15 @@
  *******************************************************************************/
 package com.tasktop.servlet.cors;
 
-class ForbiddenException extends RuntimeException {
+class Preconditions {
 
-	private static final long serialVersionUID = 1L;
+	public static void checkArgument(boolean condition) {
+		if (!condition) {
+			throw new IllegalArgumentException();
+		}
+	}
 
-	ForbiddenException(String message) {
-		super(message);
+	private Preconditions() {
+		// prevent instantiation
 	}
 }

--- a/src/main/java/com/tasktop/servlet/cors/RequestPathMatcher.java
+++ b/src/main/java/com/tasktop/servlet/cors/RequestPathMatcher.java
@@ -1,0 +1,57 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Tasktop Technologies.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package com.tasktop.servlet.cors;
+
+import static com.tasktop.servlet.cors.Preconditions.checkArgument;
+import static java.util.Objects.requireNonNull;
+import static java.util.stream.Collectors.joining;
+
+import java.text.MessageFormat;
+import java.util.List;
+import java.util.regex.Pattern;
+
+import javax.servlet.http.HttpServletRequest;
+
+class RequestPathMatcher {
+	private static final String PATTERN_OR = "|";
+
+	private final Pattern pathPattern;
+
+	RequestPathMatcher(List<String> paths) {
+		requireNonNull(paths);
+		checkArgument(!paths.isEmpty());
+		this.pathPattern = Pattern.compile(
+				"^(" + paths.stream().map(UriDecoder::decode).map(Pattern::quote).collect(joining(PATTERN_OR)) + ").*");
+	}
+
+	boolean matches(HttpServletRequest request) {
+		return pathPattern.matcher(getRequestUriWithoutContextPath(request)).matches();
+	}
+
+	private String getRequestUriWithoutContextPath(HttpServletRequest request) {
+		String requestUri = UriDecoder.decode(request.getRequestURI());
+		String contextPath = UriDecoder.decode(request.getContextPath());
+		checkContextPath(requestUri, contextPath);
+		return requestUri.substring(contextPath.length());
+	}
+
+	private void checkContextPath(String requestUri, String contextPath) {
+		if (!requestUri.startsWith(contextPath)) {
+			throw new IllegalStateException(
+					MessageFormat.format("Path \"{1}\" must start with context path \"{1}\"", requestUri, contextPath));
+		}
+	}
+}

--- a/src/main/java/com/tasktop/servlet/cors/UriDecoder.java
+++ b/src/main/java/com/tasktop/servlet/cors/UriDecoder.java
@@ -15,11 +15,17 @@
  *******************************************************************************/
 package com.tasktop.servlet.cors;
 
-class ForbiddenException extends RuntimeException {
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 
-	private static final long serialVersionUID = 1L;
+class UriDecoder {
 
-	ForbiddenException(String message) {
-		super(message);
+	public static String decode(String path) {
+		try {
+			return URLDecoder.decode(path, StandardCharsets.UTF_8.name());
+		} catch (UnsupportedEncodingException e) {
+			throw new RuntimeException(e);
+		}
 	}
 }

--- a/src/test/java/com/tasktop/servlet/cors/ConfigurationParameterParserTest.java
+++ b/src/test/java/com/tasktop/servlet/cors/ConfigurationParameterParserTest.java
@@ -1,0 +1,66 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Tasktop Technologies.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package com.tasktop.servlet.cors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class ConfigurationParameterParserTest {
+	@Rule
+	public final ExpectedException thrown = ExpectedException.none();
+
+	@Test
+	public void parseExclusionPathsRejectsEmptyValue() {
+		thrown.expect(IllegalArgumentException.class);
+		thrown.expectMessage("When specified, exclusion-paths must have at least one value");
+		ConfigurationParameterParser.parseExclusionPaths("   \t\n\r\n");
+	}
+
+	@Test
+	public void parseExclusionPathsWithMultipleValuesSeparatedByComma() {
+		List<String> value = ConfigurationParameterParser.parseExclusionPaths("one,two");
+		assertThat(value).containsExactly("/one", "/two");
+	}
+
+	@Test
+	public void parseExclusionPathsWithMultipleValuesSeparatedByWhitespace() {
+		List<String> value = ConfigurationParameterParser.parseExclusionPaths("  one\n\ttwo   ");
+		assertThat(value).containsExactly("/one", "/two");
+	}
+
+	@Test
+	public void parseExclusionPathsWithSingleValue() {
+		List<String> value = ConfigurationParameterParser.parseExclusionPaths("  one\n\t   ");
+		assertThat(value).containsExactly("/one");
+	}
+
+	@Test
+	public void parseExclusionPathsPrependsSlashOnlyIfNeeded() {
+		List<String> value = ConfigurationParameterParser.parseExclusionPaths("/one,two");
+		assertThat(value).containsExactly("/one", "/two");
+	}
+
+	@Test
+	public void parseExclusionPathsIgnoresEmptyValues() {
+		List<String> value = ConfigurationParameterParser.parseExclusionPaths("/one,,");
+		assertThat(value).containsExactly("/one");
+	}
+}

--- a/src/test/java/com/tasktop/servlet/cors/CorsHeaderScrutinyServletFilterTest.java
+++ b/src/test/java/com/tasktop/servlet/cors/CorsHeaderScrutinyServletFilterTest.java
@@ -1,3 +1,18 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Tasktop Technologies.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
 package com.tasktop.servlet.cors;
 
 import static org.mockito.Matchers.any;
@@ -39,7 +54,7 @@ public class CorsHeaderScrutinyServletFilterTest {
 
 	private final HttpServletRequest request = mock(HttpServletRequest.class);
 
-	private final CorsHeaderScrutinyServletFilter filter = new CorsHeaderScrutinyServletFilter();
+	private CorsHeaderScrutinyServletFilter filter = new CorsHeaderScrutinyServletFilter();
 
 	private final FilterChain chain = mock(FilterChain.class);
 
@@ -61,8 +76,7 @@ public class CorsHeaderScrutinyServletFilterTest {
 	@Test
 	public void doFilterAcceptsRequestWithoutOriginOrReferer() throws IOException, ServletException {
 		filter.doFilter(request, response, chain);
-		verify(chain).doFilter(request, response);
-		verifyNoMoreInteractions(chain);
+		expectAccepted();
 	}
 
 	@Test
@@ -94,8 +108,7 @@ public class CorsHeaderScrutinyServletFilterTest {
 		mockHeader(HTTP_HEADER_HOST, "a-different-host");
 		mockHeader(HTTP_HEADER_X_FORWARDED_HOST, "a-host");
 		filter.doFilter(request, response, chain);
-		verify(chain).doFilter(request, response);
-		verifyNoMoreInteractions(chain);
+		expectAccepted();
 	}
 
 	@Test
@@ -129,8 +142,7 @@ public class CorsHeaderScrutinyServletFilterTest {
 		mockHeader(HTTP_HEADER_ORIGIN, "http://a-host");
 		mockHeader(HTTP_HEADER_HOST, "a-host");
 		filter.doFilter(request, response, chain);
-		verify(chain).doFilter(request, response);
-		verifyNoMoreInteractions(chain);
+		expectAccepted();
 	}
 
 	@Test
@@ -138,8 +150,7 @@ public class CorsHeaderScrutinyServletFilterTest {
 		mockHeader(HTTP_HEADER_ORIGIN, "http://a-host:8080");
 		mockHeader(HTTP_HEADER_HOST, "a-host:8080");
 		filter.doFilter(request, response, chain);
-		verify(chain).doFilter(request, response);
-		verifyNoMoreInteractions(chain);
+		expectAccepted();
 	}
 
 	@Test
@@ -147,8 +158,7 @@ public class CorsHeaderScrutinyServletFilterTest {
 		mockHeader(HTTP_HEADER_ORIGIN, "http://a-host:9999");
 		mockHeader(HTTP_HEADER_HOST, "a-host:8080");
 		filter.doFilter(request, response, chain);
-		verify(chain).doFilter(request, response);
-		verifyNoMoreInteractions(chain);
+		expectAccepted();
 	}
 
 	@Test
@@ -169,6 +179,28 @@ public class CorsHeaderScrutinyServletFilterTest {
 	public void doFilterRejectsRequestWithRefererWithDifferentHost() throws IOException, ServletException {
 		mockHeader(HTTP_HEADER_REFERER, "http://a-host/some/path");
 		mockHeader(HTTP_HEADER_HOST, "a-different-host");
+		filter.doFilter(request, response, chain);
+		expectForbidden();
+	}
+
+	@Test
+	public void doFilterAcceptsRequestWithRefererWithDifferentHostOnExcludedPath()
+			throws IOException, ServletException {
+		filter = newFilterWithExcludedPath("/a-path");
+		mockHeader(HTTP_HEADER_REFERER, "http://a-host/some/path");
+		mockHeader(HTTP_HEADER_HOST, "a-different-host");
+		mockRequestUri("", "/a-path");
+		filter.doFilter(request, response, chain);
+		expectAccepted();
+	}
+
+	@Test
+	public void doFilterRejectsRequestWithRefererWithDifferentHostOnExcludedPath()
+			throws IOException, ServletException {
+		filter = newFilterWithExcludedPath("/a-path");
+		mockHeader(HTTP_HEADER_REFERER, "http://a-host/some/path");
+		mockHeader(HTTP_HEADER_HOST, "a-different-host");
+		mockRequestUri("", "/a-different-path");
 		filter.doFilter(request, response, chain);
 		expectForbidden();
 	}
@@ -195,8 +227,7 @@ public class CorsHeaderScrutinyServletFilterTest {
 		mockHeader(HTTP_HEADER_REFERER, "http://a-host/some/path");
 		mockHeader(HTTP_HEADER_HOST, "a-host");
 		filter.doFilter(request, response, chain);
-		verify(chain).doFilter(request, response);
-		verifyNoMoreInteractions(chain);
+		expectAccepted();
 	}
 
 	@Test
@@ -205,8 +236,25 @@ public class CorsHeaderScrutinyServletFilterTest {
 		mockHeader(HTTP_HEADER_ORIGIN, "http://a-host");
 		mockHeader(HTTP_HEADER_HOST, "a-host");
 		filter.doFilter(request, response, chain);
+		expectAccepted();
+	}
+
+	private void mockRequestUri(String contextPath, String requestPath) {
+		doReturn(contextPath).when(request).getContextPath();
+		doReturn(requestPath).when(request).getRequestURI();
+	}
+
+	private CorsHeaderScrutinyServletFilter newFilterWithExcludedPath(String pathPrefix) throws ServletException {
+		CorsHeaderScrutinyServletFilter filter = new CorsHeaderScrutinyServletFilter();
+		FilterConfig config = mock(FilterConfig.class);
+		doReturn(pathPrefix).when(config).getInitParameter(InitParameterNames.EXCLUSION_PATHS);
+		filter.init(config);
+		return filter;
+	}
+
+	private void expectAccepted() throws IOException, ServletException {
 		verify(chain).doFilter(request, response);
-		verifyNoMoreInteractions(chain);
+		verifyNoMoreInteractions(chain, response);
 	}
 
 	private void expectForbidden() throws IOException {

--- a/src/test/java/com/tasktop/servlet/cors/RequestPathMatcherTest.java
+++ b/src/test/java/com/tasktop/servlet/cors/RequestPathMatcherTest.java
@@ -1,0 +1,128 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Tasktop Technologies.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package com.tasktop.servlet.cors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class RequestPathMatcherTest {
+	private static final String ROOT_CONTEXT_PATH = "";
+	private RequestPathMatcher matcher = new RequestPathMatcher(Arrays.asList("/first-path", "/second-path"));
+	@Rule
+	public final ExpectedException thrown = ExpectedException.none();
+
+	@Test
+	public void rejectsEmptyPaths() {
+		thrown.expect(IllegalArgumentException.class);
+		new RequestPathMatcher(Collections.emptyList());
+	}
+
+	@Test
+	public void requires() {
+		thrown.expect(NullPointerException.class);
+		new RequestPathMatcher(null);
+	}
+
+	@Test
+	public void matcherMatchesPathsWithPrefix() {
+		assertThat(matcher.matches(request(ROOT_CONTEXT_PATH, "/"))).isFalse();
+		assertThat(matcher.matches(request(ROOT_CONTEXT_PATH, "/first-path"))).isTrue();
+		assertThat(matcher.matches(request("/a-context-path", "/a-context-path/first-path"))).isTrue();
+		assertThat(matcher.matches(request("/a-context-path", "/a-context-path/second-path"))).isTrue();
+
+	}
+
+	@Test
+	public void matchesAllSpecifiedPaths() {
+		assertMatches(request("/second-path"));
+		assertMatches(request("/first-path"));
+	}
+
+	@Test
+	public void matchesAllSpecifiedPathsWithContextPath() {
+		assertMatches(request("/a-context-path", "/a-context-path/second-path"));
+		assertMatches(request("/a-context-path", "/a-context-path/first-path"));
+	}
+
+	@Test
+	public void matchesPathExactly() {
+		assertMatches(request("/second-path"));
+		assertMatches(request("/second-path/"));
+	}
+
+	@Test
+	public void matchesPathExactlyWithContextPath() {
+		assertMatches(request("/a-context-path", "/a-context-path/second-path"));
+		assertMatches(request("/a-context-path", "/a-context-path/second-path/"));
+	}
+
+	@Test
+	public void rejectsBadContextPath() {
+		HttpServletRequest request = request("/a-context-path", "/path-without-context");
+		thrown.expect(IllegalStateException.class);
+		thrown.expectMessage("Path \"/a-context-path\" must start with context path \"/a-context-path\"");
+		matcher.matches(request);
+	}
+
+	@Test
+	public void matchesUriEncodedPaths() {
+		matcher = new RequestPathMatcher(Arrays.asList("/path+with+spaces"));
+		assertMatches(request("/path%20with%20spaces"));
+	}
+
+	@Test
+	public void matchesDoesNotMatchOtherPaths() {
+		assertMatchesDoesNotMatch(request(""));
+		assertMatchesDoesNotMatch(request("/"));
+		assertMatchesDoesNotMatch(request("/different-path"));
+	}
+
+	@Test
+	public void matchesDoesNotMatchOtherPathsWithContextPath() {
+		assertMatchesDoesNotMatch(request("/a-context-path", "/a-context-path"));
+		assertMatchesDoesNotMatch(request("/a-context-path", "/a-context-path/"));
+		assertMatchesDoesNotMatch(request("/a-context-path", "/a-context-path/different-path"));
+	}
+
+	private void assertMatchesDoesNotMatch(HttpServletRequest request) {
+		assertThat(matcher.matches(request)).isFalse();
+	}
+
+	private void assertMatches(HttpServletRequest request) {
+		assertThat(matcher.matches(request)).isTrue();
+	}
+
+	private HttpServletRequest request(String path) {
+		return request("", path);
+	}
+
+	private HttpServletRequest request(String contextPath, String path) {
+		HttpServletRequest request = mock(HttpServletRequest.class);
+		doReturn(contextPath).when(request).getContextPath();
+		doReturn(path).when(request).getRequestURI();
+		return request;
+	}
+}

--- a/src/test/java/com/tasktop/servlet/cors/UriDecoderTest.java
+++ b/src/test/java/com/tasktop/servlet/cors/UriDecoderTest.java
@@ -15,11 +15,25 @@
  *******************************************************************************/
 package com.tasktop.servlet.cors;
 
-class ForbiddenException extends RuntimeException {
+import static org.assertj.core.api.Assertions.assertThat;
 
-	private static final long serialVersionUID = 1L;
+import org.junit.Test;
 
-	ForbiddenException(String message) {
-		super(message);
+public class UriDecoderTest {
+
+	@Test
+	public void decode() {
+		assertThat(UriDecoder.decode("a path")).isEqualTo("a path");
+	}
+
+	@Test
+	public void decodeEmpty() {
+		assertThat(UriDecoder.decode("")).isEqualTo("");
+	}
+
+	@Test
+	public void decodePathWithEncodedSpaces() {
+		assertThat(UriDecoder.decode("one%20two")).isEqualTo("one two");
+		assertThat(UriDecoder.decode("one+two")).isEqualTo("one two");
 	}
 }


### PR DESCRIPTION
Enable use of init-param configuration to exclude requests on specified
paths from header scrutiny.

Closes Tasktop/cors-servlet-filter#3 Tasktop/cors-servlet-filter#2

Co-authored-by: "André De Bakker" <andre.bakker@tasktop.com>
Co-authored-by: "Brian Ho" <brian.ho@tasktop.com>